### PR TITLE
Added custom support for sslv3 with openssl/curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILDTAGS=
 
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
 TAG?=0.16.2
-REGISTRY?=quay.io/kubernetes-ingress-controller
+REGISTRY?=quay.io/soundtrackyourbrand
 GOOS?=linux
 DOCKER?=docker
 SED_I?=sed -i
@@ -59,7 +59,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.53
+BASEIMAGE?=quay.io/soundtrackyourbrand/nginx-$(ARCH):0.53
 
 ifeq ($(ARCH),arm)
 	QEMUARCH=arm
@@ -149,7 +149,7 @@ clean:
 build: clean
 	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -a -installsuffix cgo \
 		-ldflags "-s -w -X ${PKG}/version.RELEASE=${TAG} -X ${PKG}/version.COMMIT=${COMMIT} -X ${PKG}/version.REPO=${REPO_INFO}" \
-		-o ${TEMP_DIR}/rootfs/nginx-ingress-controller ${PKG}/cmd/nginx	
+		-o ${TEMP_DIR}/rootfs/nginx-ingress-controller ${PKG}/cmd/nginx
 
 .PHONY: verify-all
 verify-all:

--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -14,7 +14,7 @@
 
 # 0.0.0 shouldn't clobber any released builds
 TAG ?= 0.53
-REGISTRY ?= quay.io/kubernetes-ingress-controller
+REGISTRY ?= quay.io/soundtrackyourbrand
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= docker
 


### PR DESCRIPTION
Adds openssl version openssl-1.0.2o which supports SSLv3.

Images are uploaded to quay and used within https://github.com/soundtrackyourbrand/devops/tree/master/ingress-nginx